### PR TITLE
Add better support for axis directions on extended game controllers

### DIFF
--- a/PVSNES/PVSNES/SNES/PVSNESEmulatorCore.mm
+++ b/PVSNES/PVSNES/SNES/PVSNESEmulatorCore.mm
@@ -30,6 +30,7 @@
 #import "OETimingUtils.h"
 #import <OpenGLES/EAGL.h>
 #import <OpenGLES/ES3/gl.h>
+#import "PVGameControllerUtilities.h"
 
 #include "memmap.h"
 #include "pixform.h"
@@ -399,10 +400,12 @@ static void FinalizeSamplesAudioCallback(void *)
             GCExtendedGamepad *pad = [controller extendedGamepad];
             GCControllerDirectionPad *dpad = [pad dpad];
 
-            S9xReportButton(playerMask | PVSNESButtonUp, dpad.up.pressed?:pad.leftThumbstick.up.pressed);
-            S9xReportButton(playerMask | PVSNESButtonDown, dpad.down.pressed?:pad.leftThumbstick.down.pressed);
-            S9xReportButton(playerMask | PVSNESButtonLeft, dpad.left.pressed?:pad.leftThumbstick.left.pressed);
-            S9xReportButton(playerMask | PVSNESButtonRight, dpad.right.pressed?:pad.leftThumbstick.right.pressed);
+            PVControllerAxisDirection axisDirection = [PVGameControllerUtilities axisDirectionForThumbstick:pad.leftThumbstick];
+
+            S9xReportButton(playerMask | PVSNESButtonUp, dpad.up.pressed ?: axisDirection == PVControllerAxisDirectionUp);
+            S9xReportButton(playerMask | PVSNESButtonDown, dpad.down.pressed ?: axisDirection == PVControllerAxisDirectionDown);
+            S9xReportButton(playerMask | PVSNESButtonLeft, dpad.left.pressed ?: axisDirection == PVControllerAxisDirectionLeft);
+            S9xReportButton(playerMask | PVSNESButtonRight, dpad.right.pressed ?: axisDirection == PVControllerAxisDirectionRight);
 
             S9xReportButton(playerMask | PVSNESButtonB, pad.buttonA.pressed);
             S9xReportButton(playerMask | PVSNESButtonA, pad.buttonB.pressed);

--- a/PVSupport/PVSupport.xcodeproj/project.pbxproj
+++ b/PVSupport/PVSupport.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		1AD482481BA363A400FDA50A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ACEA64717F7467D0031B1C9 /* Foundation.framework */; };
 		1AD4BC6B1BFD381C007D6C7C /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD4BC6A1BFD381C007D6C7C /* AVFoundation.framework */; };
 		1AD4BC711BFD3920007D6C7C /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD4BC701BFD3920007D6C7C /* AVFoundation.framework */; };
+		25A64E131CB1BBEB00EDD19D /* PVGameControllerUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A64E121CB1BBEB00EDD19D /* PVGameControllerUtilities.m */; };
+		25A64E141CB1BDBA00EDD19D /* PVGameControllerUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A64E121CB1BBEB00EDD19D /* PVGameControllerUtilities.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -79,6 +81,8 @@
 		1AD4824E1BA363A400FDA50A /* libPVSupportTV.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPVSupportTV.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		1AD4BC6A1BFD381C007D6C7C /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.0.sdk/System/Library/Frameworks/AVFoundation.framework; sourceTree = DEVELOPER_DIR; };
 		1AD4BC701BFD3920007D6C7C /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		25A64E111CB1BBEB00EDD19D /* PVGameControllerUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVGameControllerUtilities.h; sourceTree = "<group>"; };
+		25A64E121CB1BBEB00EDD19D /* PVGameControllerUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PVGameControllerUtilities.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,12 +161,14 @@
 		1ACEA64917F7467D0031B1C9 /* PVSupport */ = {
 			isa = PBXGroup;
 			children = (
+				1ACEA6A017F74A5A0031B1C9 /* NSObject+PVAbstractAdditions.h */,
+				1ACEA6A117F74A5A0031B1C9 /* NSObject+PVAbstractAdditions.m */,
 				1ACEA68E17F748F80031B1C9 /* OETimingUtils.h */,
 				1ACEA69717F748F80031B1C9 /* OETimingUtils.m */,
 				1ACEA68F17F748F80031B1C9 /* PVEmulatorCore.h */,
 				1ACEA69817F748F80031B1C9 /* PVEmulatorCore.m */,
-				1ACEA6A017F74A5A0031B1C9 /* NSObject+PVAbstractAdditions.h */,
-				1ACEA6A117F74A5A0031B1C9 /* NSObject+PVAbstractAdditions.m */,
+				25A64E111CB1BBEB00EDD19D /* PVGameControllerUtilities.h */,
+				25A64E121CB1BBEB00EDD19D /* PVGameControllerUtilities.m */,
 				1ACEA64A17F7467D0031B1C9 /* Supporting Files */,
 			);
 			path = PVSupport;
@@ -264,6 +270,7 @@
 				1ACEA69A17F748F80031B1C9 /* OERingBuffer.m in Sources */,
 				1ACEA6A217F74A5A0031B1C9 /* NSObject+PVAbstractAdditions.m in Sources */,
 				1ACEA69C17F748F80031B1C9 /* OETimingUtils.m in Sources */,
+				25A64E131CB1BBEB00EDD19D /* PVGameControllerUtilities.m in Sources */,
 				1ACEA69D17F748F80031B1C9 /* PVEmulatorCore.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -273,6 +280,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1AD4823D1BA363A400FDA50A /* TPCircularBuffer.c in Sources */,
+				25A64E141CB1BDBA00EDD19D /* PVGameControllerUtilities.m in Sources */,
 				1AD4823E1BA363A400FDA50A /* OEGameAudio.m in Sources */,
 				1AD4823F1BA363A400FDA50A /* OERingBuffer.m in Sources */,
 				1AD482401BA363A400FDA50A /* NSObject+PVAbstractAdditions.m in Sources */,

--- a/PVSupport/PVSupport/PVGameControllerUtilities.h
+++ b/PVSupport/PVSupport/PVGameControllerUtilities.h
@@ -1,0 +1,21 @@
+//
+//  PVGameControllerUtilities.h
+//  PVSupport
+//
+//  Created by Tyler Hedrick on 4/3/16.
+//  Copyright © 2016 James Addyman. All rights reserved.
+//
+
+@class GCControllerDirectionPad;
+
+typedef NS_ENUM(NSUInteger, PVControllerAxisDirection) {
+    PVControllerAxisDirectionNone,
+    PVControllerAxisDirectionUp,
+    PVControllerAxisDirectionDown,
+    PVControllerAxisDirectionLeft,
+    PVControllerAxisDirectionRight
+};
+
+@interface PVGameControllerUtilities : NSObject
++ (PVControllerAxisDirection)axisDirectionForThumbstick:(GCControllerDirectionPad *)thumbstick;
+@end

--- a/PVSupport/PVSupport/PVGameControllerUtilities.m
+++ b/PVSupport/PVSupport/PVGameControllerUtilities.m
@@ -1,0 +1,33 @@
+//
+//  PVGameControllerUtilities.m
+//  PVSupport
+//
+//  Created by Tyler Hedrick on 4/3/16.
+//  Copyright © 2016 James Addyman. All rights reserved.
+//
+
+#import "PVGameControllerUtilities.h"
+
+#import <GameController/GameController.h>
+
+@implementation PVGameControllerUtilities
+
++ (PVControllerAxisDirection)axisDirectionForThumbstick:(GCControllerDirectionPad *)thumbstick {
+    static CGFloat thumbstickSensitivty = 0.1;
+    BOOL isXAxis = (fabsf(thumbstick.xAxis.value) > fabsf(thumbstick.yAxis.value));
+    if (!isXAxis && thumbstick.yAxis.value >= thumbstickSensitivty) {
+        return PVControllerAxisDirectionUp;
+    }
+    if (!isXAxis && thumbstick.yAxis.value <= -thumbstickSensitivty) {
+        return PVControllerAxisDirectionDown;
+    }
+    if (isXAxis && thumbstick.xAxis.value <= -thumbstickSensitivty) {
+        return PVControllerAxisDirectionLeft;
+    }
+    if (isXAxis && thumbstick.xAxis.value >= thumbstickSensitivty) {
+        return PVControllerAxisDirectionRight;
+    }
+    return PVControllerAxisDirectionNone;
+}
+
+@end


### PR DESCRIPTION
This adds improved logic for controllers with thumbsticks to determine the current direction of either stick. Before this change, the logic alwasy preferred the yAxis of the thumbstick making it difficult to move along the xAxis in games. I started by adding the directional support to the SNES emulator since that's what I've been playing, but I put it in a category so it can be easily used in the other emulator cores. Please let me know if I put files in the right places / if I should add this axis support to the other emulator cores as well. Thanks!